### PR TITLE
Fix return type for DevCacheClient get response

### DIFF
--- a/src/dev-cache-client.ts
+++ b/src/dev-cache-client.ts
@@ -8,7 +8,7 @@ export class DevCacheClientAbs {
    * Returns the JSON.parsable value located at the key (if any). Always returns null when
    * the client is a noop client.
    */
-  get(_key: string): Promise<string | null | void> {
+  get(_key: string): Promise<object | null | void> {
     throw Error('Method not implemented.');
   }
   /**
@@ -45,7 +45,7 @@ export class DevCacheClient extends DevCacheClientAbs {
     }
   }
 
-  async get(key: string) {
+  async get(key: string): Promise<object | null> {
     const cached = await this.client.get(key);
     return cached ? JSON.parse(cached) : null;
   }


### PR DESCRIPTION
This pull request updates the `get` method signatures in both the abstract and concrete implementations of the dev cache client to clarify their return types. The method now explicitly returns a parsed object (or null), improving type safety and clarity.

Type signature improvements:

* Updated the return type of the `get` method in `DevCacheClientAbs` from `Promise<string | null | void>` to `Promise<object | null | void>`, indicating that the method should return a parsed object instead of a raw string.
* Updated the return type of the `get` method in `DevCacheClient` from an implicit type to `Promise<object | null>`, ensuring that the method always returns a parsed object or null.