### PR TITLE
add generic types for get/set to resolve downstream type checks

### DIFF
--- a/src/dev-cache-client.ts
+++ b/src/dev-cache-client.ts
@@ -1,6 +1,9 @@
 import type { RedisClientType } from 'redis';
 
 export class DevCacheClientAbs {
+  /**
+   * Connects to the cache or does nothing for noop clients.
+   */
   connect(): Promise<void> {
     throw Error('Method not implemented.');
   }
@@ -8,7 +11,7 @@ export class DevCacheClientAbs {
    * Returns the JSON.parsable value located at the key (if any). Always returns null when
    * the client is a noop client.
    */
-  get(_key: string): Promise<object | null | void> {
+  get<T>(_key: string): Promise<T | null | void> {
     throw Error('Method not implemented.');
   }
   /**
@@ -16,7 +19,7 @@ export class DevCacheClientAbs {
    * @param _key
    * @param _value - stringified before saving in cache
    */
-  set(_key: string, _value: object): Promise<void> {
+  set<T>(_key: string, _value: T): Promise<void> {
     throw Error('Method not implemented');
   }
   /**
@@ -45,12 +48,12 @@ export class DevCacheClient extends DevCacheClientAbs {
     }
   }
 
-  async get(key: string): Promise<object | null> {
+  async get<T>(key: string): Promise<T | null> {
     const cached = await this.client.get(key);
     return cached ? JSON.parse(cached) : null;
   }
 
-  async set(key: string, value: string | StringConstructor | object, ttlHours = 24) {
+  async set<T>(key: string, value: T | string | StringConstructor, ttlHours = 24) {
     if (value instanceof String) {
       value = value.toString();
     }


### PR DESCRIPTION
This pull request updates the `DevCacheClientAbs` and `DevCacheClient` classes to make the cache client methods generic, allowing for improved type safety and flexibility when storing and retrieving values from the cache.

Type safety and generics improvements:

* Updated the `get` and `set` methods in both `DevCacheClientAbs` and `DevCacheClient` to use TypeScript generics, so that the type of cached values can be specified by the caller, improving type safety and reducing the need for casting. [[1]](diffhunk://#diff-6c790cd21c8f8281abfde57f26ad3bb76f8a452fead570d3034c81b36934b895R4-R22) [[2]](diffhunk://#diff-6c790cd21c8f8281abfde57f26ad3bb76f8a452fead570d3034c81b36934b895L48-R56)
* Updated the `set` method in `DevCacheClient` to accept values of generic type `T`, `string`, or `StringConstructor`, providing more flexibility in what can be cached.